### PR TITLE
Switch verify off to get around SSL cert error

### DIFF
--- a/splunk_logger/splunk_logger.py
+++ b/splunk_logger/splunk_logger.py
@@ -104,6 +104,6 @@ class SplunkLogger(logging.Handler):
         params['host'] = host
 
         url = '%s?%s' % (self.url, urllib.urlencode(params))
-        return self.session.post(url, data=event)
+        return self.session.post(url, data=event, verify=False)
 
 


### PR DESCRIPTION
splunkstorm is using a cert that doesn't match the api endpoint - SSL complains about this unless you switch verify off. Not ideal, but functional.
